### PR TITLE
Remove the shell app menu

### DIFF
--- a/AudioCutter/__init__.py
+++ b/AudioCutter/__init__.py
@@ -20,4 +20,4 @@ from .application import Application
 from .widgets import HeaderBar, Window
 from .const import AUDIO_MIMES
 from .objects import Time
-from .utils import show_app_menu, format_ns
+from .utils import format_ns

--- a/AudioCutter/application.py
+++ b/AudioCutter/application.py
@@ -19,7 +19,6 @@ from gettext import gettext as _
 
 from .widgets import Window, AboutDialog, ShortuctsWindow, SettingsWindow
 from .modules import Logger, Settings
-from .utils import show_app_menu
 
 from gi import require_version
 require_version("Gtk", "3.0")
@@ -108,9 +107,6 @@ class Application(Gtk.Application):
         action = Gio.SimpleAction.new("quit", None)
         action.connect("activate", self._on_quit)
         self.add_action(action)
-        if show_app_menu():
-            self.set_app_menu(self.app_menu)
-            Logger.debug("Adding GNOME app menu")
 
     def _on_night_mode(self, action, *args):
         """Switch the night mode on/off."""

--- a/AudioCutter/utils.py
+++ b/AudioCutter/utils.py
@@ -21,10 +21,6 @@ from os import path, makedirs
 from gi.repository import GLib
 
 
-def show_app_menu():
-    """Return if we should use the app_menu or use a popover."""
-    return "gnome" in GLib.getenv("XDG_CURRENT_DESKTOP").lower()
-
 def get_wavefile_location_for_uri(uri):
     filename = sha256(uri.encode("utf-8")).hexdigest()
     cachedir = path.join(GLib.get_user_cache_dir(), "AudioCutter")


### PR DESCRIPTION
GNOME Shell is removing it's application menu in 3.32. Since
a popover is already used, we can just remove the code that handles exporting it to the shell.